### PR TITLE
Input dask array to np.linalg.svd

### DIFF
--- a/_posts/2019-03-18-dask-nep18.md
+++ b/_posts/2019-03-18-dask-nep18.md
@@ -40,7 +40,7 @@ x = np.random.random((5000, 1000))
 
 d = da.from_array(x, chunks=(1000, 1000))
 
-u, s, v = np.linalg.svd(x)
+u, s, v = np.linalg.svd(d)
 ```
 
 Now consider we want to speedup the SVD computation of a Dask array and offload
@@ -58,7 +58,7 @@ x = cupy.random.random((5000, 1000))
 
 d = da.from_array(x, chunks=(1000, 1000))
 
-u, s, v = np.linalg.svd(x)
+u, s, v = np.linalg.svd(d)
 ```
 
 We could do the same for a Sparse array, or any other NumPy-like array that


### PR DESCRIPTION
I could be missing something, but are these two `np.linalg.svd` function calls supposed to have dask arrays as input?

cc @pentschev 