### PR TITLE
Use pkg-config (instead of pkgconfig)

### DIFF
--- a/_posts/2019-06-09-ucx-dgx.md
+++ b/_posts/2019-06-09-ucx-dgx.md
@@ -511,7 +511,7 @@ Create Conda Environment
 ------------------------
 
 ```
-conda create -n ucx python=3.7 libtool cmake automake autoconf cython bokeh pytest pkgconfig ipython dask numba -y
+conda create -n ucx python=3.7 libtool cmake automake autoconf cython bokeh pytest pkg-config ipython dask numba -y
 ```
 
 Note: for some reason using conda-forge makes the autogen step below fail.


### PR DESCRIPTION
The former is a Unix build tool, which is needed when building things that leverage autotools. The latter is a Python package for interacting with that Unix build tool. We are only using the former in our UCX build.

ref: https://github.com/conda-forge/pkgconfig-feedstock/issues/4