### PR TITLE
Corrects Dask-ML version number in Dask 2.2 release post

### DIFF
--- a/_posts/2019-08-02-dask-2.2.md
+++ b/_posts/2019-08-02-dask-2.2.md
@@ -197,7 +197,7 @@ Thanks to [Jacob Tomlinson](https://github.com/jacobtomlinson) for this work.
 3 - Hyperparameter selection with HyperBand
 -------------------------------------------
 
-Dask-ML 2.1 was released with a new `HyperBandSearchCV` meta-estimator for
+Dask-ML 1.0 has been released with a new `HyperBandSearchCV` meta-estimator for
 hyper-parameter optimization. This can be used as an alternative to
 `RandomizedSearchCV` to find similar hyper-parameters in less time by not
 wasting time on hyper-parameters that are not promising.


### PR DESCRIPTION
**What does this PR implement?**
This PR corrects the Dask-ML version number from 2.1 to 1.0

[GitHub][github], [PyPI][pypi] and [conda-forge][conda] all indicate Dask-ML's latest version is 1.0. Is this a mistake?

[pypi]:https://pypi.org/project/dask-ml/#history
[github]:https://github.com/dask/dask-ml/releases
[conda]:https://anaconda.org/conda-forge/dask-ml