### PR TITLE
Add GitHub Pages refresh workflow to rebuild the blog daily

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,17 @@
+name: Refresh
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Runs every day at 3am
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitHub pages rebuild
+        run: |
+          curl --fail --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/pages/builds \
+            --header "Authorization: Bearer $BOT_TOKEN"
+        env:
+          BOT_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Actions workflow will cause the GitHub Pages site for the Dask Blog to be rebuilt every day at 3am UTC.

Currently, the site only gets built when something is merged into the `gh-pages` branch.

This workflow would enable us to future date blog posts, which will not get built into the site until that date (Jekyll does this automatically). By triggering the build daily we can schedule blog posts to go out in the future simply by future dating them and merging ahead of time.

cc @jsignell @mrocklin 