### PR TITLE
Fix typo in image segmentation blogpost

### DIFF
--- a/_posts/2021-03-19-image-segmentation.md
+++ b/_posts/2021-03-19-image-segmentation.md
@@ -53,7 +53,7 @@ smoothed = ndfilters.gaussian_filter(images, sigma=[0, 1, 1])
 thresh = ndfilters.threshold_local(smoothed, blocksize=images.chunksize)
 threshold_images = smoothed > thresh
 structuring_element = np.array([[[0, 0, 0], [0, 0, 0], [0, 0, 0]], [[0, 1, 0], [1, 1, 1], [0, 1, 0]], [[0, 0, 0], [0, 0, 0], [0, 0, 0]]])
-binary_images = ndmorph.binary_closing(threshold_image)
+binary_images = ndmorph.binary_closing(threshold_image, structure=structuring_element)
 label_images, num_features = ndmeasure.label(binary_image)
 index = np.arange(num_features)
 area = ndmeasure.area(images, label_images, index)


### PR DESCRIPTION
An eagle eyed reader has pointed out a typo in the image segmentation blogpost: https://twitter.com/TobiasAdeJong/status/1374263891539193858

This PR fixes that so the "just show me the code" section is consistent.