### PR TITLE
Fix title formatting in post, change colon to comma

### DIFF
--- a/_posts/2021-07-02-ragged-output.md
+++ b/_posts/2021-07-02-ragged-output.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Ragged output: how to handle awkward shaped results
+title: Ragged output, how to handle awkward shaped results
 author: Genevieve Buckley
 theme: twitter
 ---


### PR DESCRIPTION
I suspect the reason the newest post title isn't being shown is that there is a colon `:` in the title. Testing this theory by changing it to a comma, I think that should fix it.

![image](https://user-images.githubusercontent.com/30920819/124229814-85e2cf80-db51-11eb-9dea-f655ff1fd752.png)
