### PR TITLE
Fix broken mybinder links for dask-examples notebooks

### DIFF
--- a/_posts/2018-07-08-dask-dev.md
+++ b/_posts/2018-07-08-dask-dev.md
@@ -83,8 +83,8 @@ learning, etc.
 Now [Scott Sievert](https://stsievert.com/) is expanding the examples within
 the machine learning section.  He has submitted the following two so far:
 
-1.  [Incremental training with Scikit-Learn and large datasets](https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=machine-learning%2Fincremental.ipynb)
-2.  [Dask and XGBoost](https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=machine-learning%2Fxgboost.ipynb)
+1.  [Incremental training with Scikit-Learn and large datasets](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fmachine-learning%2Fincremental.ipynb)
+2.  [Dask and XGBoost](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fmachine-learning%2Fxgboost.ipynb)
 
 I believe he's planning on more.  If you use
 [dask-ml](http://dask-ml.readthedocs.io/en/latest/) and have recommendations or

--- a/_posts/2018-09-05-dask-0.19.0.md
+++ b/_posts/2018-09-05-dask-0.19.0.md
@@ -216,7 +216,7 @@ laptop or for a small cloud instance.  These are hosted on
 A number of new examples have arisen recently, particularly in machine
 learning.  We encourage people to try them out by clicking the link below.
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main)
 
 
 Other Projects

--- a/_posts/2018-09-17-dask-dev.md
+++ b/_posts/2018-09-17-dask-dev.md
@@ -39,7 +39,7 @@ users try out Dask on a small cloud instance using
 [mybinder.org](https://mybinder.org).  If you want to try out Dask and
 JupyterLab together then head here:
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab)
 
 Thanks to [Ian Rose](https://github.com/ian-r-rose) for managing this.
 

--- a/_posts/2018-09-27-docs-refactor.md
+++ b/_posts/2018-09-27-docs-refactor.md
@@ -199,7 +199,7 @@ ways:
 
 2.  As live-runnable notebooks on the cloud using [mybinder.org](https://mybinder.org).
     You can play with any of these notebooks by clicking on this button:
-    [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab).
+    [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab).
 
     This allows people to explore more deeply.  Also, because we've connected
     up the Dask JupyterLab extension to this environment, users get an

--- a/_posts/2019-08-05-user-survey.md
+++ b/_posts/2019-08-05-user-survey.md
@@ -32,7 +32,7 @@ These results help us better understand the Dask community and will guide future
 
 The raw data, as well as the start of an analysis, can be found in this binder:
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=surveys/2019.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2019.ipynb)
 
 Let us know if you find anything in the data.
 

--- a/_posts/2020-09-22-user_survey.md
+++ b/_posts/2020-09-22-user_survey.md
@@ -33,7 +33,7 @@ These results help us better understand the Dask community and will guide future
 
 The raw data, as well as the start of an analysis, can be found in this binder:
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=surveys/2020.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2020.ipynb)
 
 Let us know if you find anything in the data.
 


### PR DESCRIPTION
All the binder badge links are broken, this PR restores that functionality.

They broke for two reasons:
1. The dask-examples "main" branch was recently renamed (previously named "master"), and
2. A backwards incompatible change happened in the way binder generates/parses links ([see here for more details](https://discourse.jupyter.org/t/bug-path-to-a-notebook-file-functionality-unexepectedly-changed-not-working-for-notebooks-in-subfolders/10811))

Neither of these should be a problem going forward. However, we will need to be careful with the way people generate binder badges for dask-examples - if you use https://mybinder.org/ it will give you a link that only works for newer versions. We can either:
- Use the link formatting with `urlpath` like in this PR, or
- Update the pinned dependencies over at dask-examples to be more modern

Cross reference: https://github.com/dask/dask-examples/issues/196
