### PR TITLE
Resize too-large images in blogposts

### DIFF
--- a/_posts/2021-03-19-image-segmentation.md
+++ b/_posts/2021-03-19-image-segmentation.md
@@ -154,7 +154,7 @@ viewer.add_image(absolute_threshold)
 viewer.add_image(images, contrast_limits=[0, 2000])
 ```
 
-![Absolute threshold napari screenshot](/images/2021-image-segmentation/napari-absolute-threshold.png)
+<img src="/images/2021-image-segmentation/napari-absolute-threshold.png" alt="Absolute threshold napari screenshot" width="700" height="476">
 
 But there's a problem here.
 
@@ -177,7 +177,7 @@ threshold_images = smoothed > thresh
 viewer.add_image(threshold_images)
 ```
 
-![Local threshold napari screenshot](/images/2021-image-segmentation/napari-local-threshold.png)
+<img src="/images/2021-image-segmentation/napari-local-threshold.png" alt="Local threshold napari screenshot" width="700" height="476">
 
 The results here look much better, this is a much cleaner separation of nuclei from the background and it looks good for all the image frames.
 
@@ -250,7 +250,7 @@ index = np.arange(num_features - 1) + 1  # [1, 2, 3, ...num_features]
 
 Here's a screenshot of the label image generated from our mask.
 
-![Label image napari screenshot](/images/2021-image-segmentation/napari-label-image.png)
+<img src="/images/2021-image-segmentation/napari-label-image.png" alt="Label image napari screenshot" width="700" height="476">
 
 ```python
 >>> print("Number of nuclei:", num_features.compute())

--- a/_posts/2021-07-07-high-level-graphs.md
+++ b/_posts/2021-07-07-high-level-graphs.md
@@ -130,8 +130,10 @@ Dask already uses HTML representations in lots of places (like the `Array` and `
 
 #### After (HTML representation):
 
-![HTML representation for a Dask high level graph](/images/2021-highlevelgraph-html-repr.png)
+<img src="/images/2021-highlevelgraph-html-repr.png" alt="HTML representation for a Dask high level graph" width="700" height="470">
+
 #### After (text-only representation):
+
 ```python
 from dask.datasets import timeseries
 

--- a/_posts/2021-09-15-user-survey.md
+++ b/_posts/2021-09-15-user-survey.md
@@ -496,7 +496,7 @@ list(data.value_counts()[data.value_counts() == 1].keys().get_level_values(0))
 
 
 
-<img src="https://imgs.xkcd.com/comics/standards_2x.png" alt="XKCD comic 927: Standards"> 
+<img src="https://imgs.xkcd.com/comics/standards.png" alt="XKCD comic 927: Standards"> 
 
 XKCD comic "Standards" https://xkcd.com/927/
 


### PR DESCRIPTION
Closes https://github.com/dask/dask-blog/issues/127

There were a few blogposts where the images displayed much larger than expected. This PR makes the image sizes more sensible in three blogposts:
- image segmentation
- high level graphs update, and 
- the 2021 Dask user survey results